### PR TITLE
Global: Change physics namespace name

### DIFF
--- a/src/maths/Matrix.cpp
+++ b/src/maths/Matrix.cpp
@@ -1,7 +1,7 @@
 #include "Matrix.hpp"
 #include <iomanip>
 
-namespace Physics{
+namespace PhysEn{
 namespace Maths{
 
 //

--- a/src/maths/Matrix.hpp
+++ b/src/maths/Matrix.hpp
@@ -3,7 +3,7 @@
 #include "Size.hpp"
 #include <ostream>
 
-namespace Physics{
+namespace PhysEn{
 namespace Maths{
 
 enum class MatrixType {Unity, Random, Zero};

--- a/src/maths/Size.cpp
+++ b/src/maths/Size.cpp
@@ -1,6 +1,6 @@
 #include "Size.hpp"
 
-namespace Physics{
+namespace PhysEn{
 
 Size::Size(){
 	this->rows = 0;

--- a/src/maths/Size.hpp
+++ b/src/maths/Size.hpp
@@ -3,7 +3,7 @@
 #include <cstddef>
 #include <iostream>
 
-namespace Physics{
+namespace PhysEn{
 
 struct Size{
 	size_t rows, columns;

--- a/src/maths/Vector.cpp
+++ b/src/maths/Vector.cpp
@@ -1,7 +1,7 @@
 #include "Vector.hpp"
 #include <math.h>
 
-namespace Physics{
+namespace PhysEn{
 namespace Maths{
 
 Vector::Vector(){

--- a/src/maths/Vector.hpp
+++ b/src/maths/Vector.hpp
@@ -2,7 +2,7 @@
 
 #include <iostream>
 
-namespace Physics{
+namespace PhysEn{
 namespace Maths{
 
 struct Vector{

--- a/src/objects/Object.cpp
+++ b/src/objects/Object.cpp
@@ -1,6 +1,6 @@
 #include "Object.hpp"
 
-namespace Physics{
+namespace PhysEn{
 namespace Objects{
 
 // Constructors

--- a/src/objects/Object.hpp
+++ b/src/objects/Object.hpp
@@ -3,7 +3,7 @@
 #include "../maths/Vector.hpp"
 #include <iostream>
 
-namespace Physics{
+namespace PhysEn{
 namespace Objects{
 
 class Object{

--- a/src/objects/ObjectCircle.cpp
+++ b/src/objects/ObjectCircle.cpp
@@ -1,6 +1,6 @@
 #include "ObjectCircle.hpp"
 
-namespace Physics{
+namespace PhysEn{
 namespace Objects{
 
 // Constructors

--- a/src/objects/ObjectCircle.hpp
+++ b/src/objects/ObjectCircle.hpp
@@ -2,7 +2,7 @@
 
 #include "Object.hpp"
 
-namespace Physics{
+namespace PhysEn{
 namespace Objects{
 
 class ObjectCircle : public Object{

--- a/src/objects/ObjectRectangle.cpp
+++ b/src/objects/ObjectRectangle.cpp
@@ -1,6 +1,6 @@
 #include "ObjectRectangle.hpp"
 
-namespace Physics{
+namespace PhysEn{
 namespace Objects{
 
 ObjectRectangle::ObjectRectangle(Maths::Vector pos, Size size) : Object(pos){

--- a/src/objects/ObjectRectangle.hpp
+++ b/src/objects/ObjectRectangle.hpp
@@ -4,7 +4,7 @@
 #include "Object.hpp"
 #include "../maths/Size.hpp"
 
-namespace Physics{
+namespace PhysEn{
 namespace Objects{
 
 class ObjectRectangle : public Object{

--- a/tests/Components.GTest.cpp
+++ b/tests/Components.GTest.cpp
@@ -4,21 +4,21 @@
 
 TEST(Size, Construction){
 	{   // Zero Size
-		Physics::Size size;
+		PhysEn::Size size;
 
 		EXPECT_EQ(size.rows, size.columns);
 		EXPECT_EQ(size.rows, 0);
 	}
 
 	{   // Custom Size
-		Physics::Size size(3, 4);
+		PhysEn::Size size(3, 4);
 
 		EXPECT_EQ(size.rows, 3);
 		EXPECT_EQ(size.columns, 4);
 	}
 
 	{   // Square Size
-		Physics::Size size(5);
+		PhysEn::Size size(5);
 
 		EXPECT_EQ(size.rows, size.columns);
 		EXPECT_EQ(size.rows, 5);
@@ -27,62 +27,62 @@ TEST(Size, Construction){
 
 TEST(Size, Operators) {
 	{   // ==
-		Physics::Size sizeOne(5);
-		Physics::Size sizeTwo(5, 5);
+		PhysEn::Size sizeOne(5);
+		PhysEn::Size sizeTwo(5, 5);
 
 		EXPECT_EQ(sizeOne, sizeTwo);
 	}
 
 	{   // +
-		Physics::Size sizeOne(4);
-		Physics::Size sizeTwo(5, 5);
+		PhysEn::Size sizeOne(4);
+		PhysEn::Size sizeTwo(5, 5);
 
-		Physics::Size sizeThree = sizeOne + sizeTwo + Physics::Size(1, 1);
-		EXPECT_EQ(sizeThree, Physics::Size(10, 10));
+		PhysEn::Size sizeThree = sizeOne + sizeTwo + PhysEn::Size(1, 1);
+		EXPECT_EQ(sizeThree, PhysEn::Size(10, 10));
 	}
 
 	{   // -
-		Physics::Size sizeOne(4);
-		Physics::Size sizeTwo(5, 5);
+		PhysEn::Size sizeOne(4);
+		PhysEn::Size sizeTwo(5, 5);
 
-		Physics::Size result = sizeOne - sizeTwo;
-		EXPECT_EQ(result, Physics::Size(0, 0)); // Size set to (0,0) if negative
+		PhysEn::Size result = sizeOne - sizeTwo;
+		EXPECT_EQ(result, PhysEn::Size(0, 0)); // Size set to (0,0) if negative
 
 		result = sizeTwo - sizeOne;
-		EXPECT_EQ(result, Physics::Size(1, 1));
+		EXPECT_EQ(result, PhysEn::Size(1, 1));
 	}
 
 	{   // +=
-		Physics::Size sizeOne(4);
-		Physics::Size sizeTwo(5, 5);
+		PhysEn::Size sizeOne(4);
+		PhysEn::Size sizeTwo(5, 5);
 
 		sizeOne += sizeTwo;
-		EXPECT_EQ(sizeOne, Physics::Size(9, 9));
+		EXPECT_EQ(sizeOne, PhysEn::Size(9, 9));
 	}
 
 	{   // -=
-		Physics::Size sizeOne(4);
-		Physics::Size sizeTwo(5, 5);
+		PhysEn::Size sizeOne(4);
+		PhysEn::Size sizeTwo(5, 5);
 
 		sizeOne -= sizeTwo;
-		EXPECT_EQ(sizeOne, Physics::Size(0, 0)); // Size set to (0,0) if negative
+		EXPECT_EQ(sizeOne, PhysEn::Size(0, 0)); // Size set to (0,0) if negative
 
-		sizeOne = Physics::Size(12, 4);
+		sizeOne = PhysEn::Size(12, 4);
 		sizeTwo -= sizeOne;
-		EXPECT_EQ(sizeTwo, Physics::Size(0, 1));  // Component set to 0 if negative
+		EXPECT_EQ(sizeTwo, PhysEn::Size(0, 1));  // Component set to 0 if negative
 	}
 
 	{   // *=
-		Physics::Size sizeOne(2, 6);
+		PhysEn::Size sizeOne(2, 6);
 		sizeOne *= 3;
 
-		EXPECT_EQ(sizeOne, Physics::Size(6, 18));
+		EXPECT_EQ(sizeOne, PhysEn::Size(6, 18));
 
 		sizeOne *= -1;
-		EXPECT_EQ(sizeOne, Physics::Size(6, 18));
+		EXPECT_EQ(sizeOne, PhysEn::Size(6, 18));
 
 		sizeOne *= 0;
-		EXPECT_EQ(sizeOne, Physics::Size(0, 0));
+		EXPECT_EQ(sizeOne, PhysEn::Size(0, 0));
 	}
 
 }

--- a/tests/Maths.GTest.cpp
+++ b/tests/Maths.GTest.cpp
@@ -3,7 +3,7 @@
 #include "../src/maths/Vector.hpp"
 #include "../src/maths/Matrix.hpp"
 
-using namespace Physics;
+using namespace PhysEn;
 /*
 class MathsTests: public ::testing::Test {
 	MathsTests() { }

--- a/tests/Physics.GTest.cpp
+++ b/tests/Physics.GTest.cpp
@@ -13,13 +13,13 @@ class PhysicsTests: public ::testing::Test {
 */
 
 TEST(ObjectTests, Update) {
-	Physics::Objects::Object firstObject(
-			Physics::Maths::Vector(0.0f, 100.0f, 0.0f),
-			Physics::Maths::Vector(20.0f, 0.0f, 0.0f),
-			Physics::Maths::Vector(0.0f, -10.0f, 0.0f)
+	PhysEn::Objects::Object firstObject(
+			PhysEn::Maths::Vector(0.0f, 100.0f, 0.0f),
+			PhysEn::Maths::Vector(20.0f, 0.0f, 0.0f),
+			PhysEn::Maths::Vector(0.0f, -10.0f, 0.0f)
 		);
 
-		Physics::Objects::Object secondObject = firstObject;
+		PhysEn::Objects::Object secondObject = firstObject;
 
 	int time = 5; // 5 seconds
 	while(time-- > 0)


### PR DESCRIPTION
**Changes:**
- Changes ```Physics``` namespace to ```PhysEn``` to fit new project name.